### PR TITLE
[Update] v1/resumes/search-jobrex/ function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ client = ResumesClient(api_key="your_api_key_here")
 query = "Data Scientist"
 top_k = 10
 
-search_response = client.search_jobrex_resumes(query, top_k=10)
+search_response = client.search_jobrex(query, top_k=10)
 print(search_response)
 ```
 

--- a/jobrex/client.py
+++ b/jobrex/client.py
@@ -101,7 +101,7 @@ class ResumesClient(BaseClient):
 
         return self._make_request('POST', 'v1/resumes/search/', json=data)
 
-    def search_jobrex_resumes(
+    def search_jobrex(
         self, 
         query: str, 
         filters: Optional[Dict] = None,


### PR DESCRIPTION
Changed the search_jobrex_resumes function name in the client to search_jobrex to match with the endpoint name 